### PR TITLE
Address issue with VEP annotation of deletions

### DIFF
--- a/annotate.py
+++ b/annotate.py
@@ -532,8 +532,8 @@ def cmd_VEP(
 
     output_lines = output_lines.apply(
         lambda row: [
-            f"{row['chr']} {row['pos']} {row['pos']} {row['a1']}/{row['a2']} +",
-            f"{row['chr']} {row['pos']} {row['pos']} {row['a1']}/{row['a2']} -",
+            f"{row['chr']} {row['pos']} {row['pos'] + len(row['a1']) - 1} {row['a1']}/{row['a2']} +",
+            f"{row['chr']} {row['pos']} {row['pos'] + len(row['a1']) - 1} {row['a1']}/{row['a2']} -",
         ],
         axis=1,
     )


### PR DESCRIPTION
Warnings during execution of `FLAMES/annotate.py` indicate that deletions are not being successfully applied to VEP annotation.  For example:
```
Starting_annotation:
WARNING: line 11 skipped (1 161136957 161136957 AT/A +): Length of reference allele (T length 1) does not match coordinates 161136958-161136957
WARNING: line 12 skipped (1 161136957 161136957 AT/A -): Length of reference allele (T length 1) does not match coordinates 161136958-161136957
```
To address this, the base position range supplied for VEP annotation was updated to include the full deleted sequence.